### PR TITLE
Browse/search URL bugfix

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/aspect/discovery/discovery.xsl
@@ -251,7 +251,7 @@
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:value-of
-                                            select="concat($context-path, '/internal-item?itemID=', $identifier)"/>
+                                            select="concat($context-path, '/handle/', $identifier)"/>
                                 </xsl:otherwise>
                             </xsl:choose>
                         </xsl:attribute>


### PR DESCRIPTION
This code changes the XSL default URL in browse and search results to use a URL prefix of "/handle/" rather than the Atmire default URL prefix of "/internal-item?itemID=". I believe that the "/internal-item" prefix is meant for DSpace installations that are not registered with the CNRI Handle Service and are not configured to use a Handle server. Since Dome is registered with CNRI and configured to use the DSpace internal Handle server implementation, we should use the "/handle/" URL prefix instead. Using the "/internal-item" URL prefix was causing NULL Pointer exceptions that were uncaught and displayed in the client's web browser. Using the "/handle/" prefix allows the links in browse and search results to work correctly. It allows the clients to access the records and assets.

This patch only changes the default case in the XSL logic. I did not review and test the XSL logic on line #243 to make sure that it was correct. It should be reviewed. I also did not test if the "/admin/item?itemID=" URL prefix, from line #245, for withdrawn items in Dome was valid or if it needs to be changed to a URL prefix such as "/admin/handle/". The use of the "/admin/item?itemID=" URL Prefix should be tested by someone with Administrative access and familiar with how to withdraw items from Dome.