### PR TITLE
Update footer based on design system changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,21 @@ This repository holds only the files necessary to change a stock DSpace
 application into the Dome platform maintained by the MIT Libraries.
 
 These files are meant to be unzipped on top of a stock DSpace 6.3 codebase.
+
+## Local development
+
+Local development is best done via Docker, using this general workflow:
+
+1. Clone the [DSpace repository](https://github.com/DSpace/DSpace), and check out the `dspace-6_x` branch.
+2. Copy the contents of this `dome-mit-custom` repository over the top of that
+   branch, overwriting and adding files as needed. Something like `cp -R *`
+   should work.
+3. Follow the [standard Docker workflow](https://github.com/DSpace/DSpace/tree/dspace-6_x/dspace/src/main/docker-compose) for building and starting the
+   application. It will appear by default at [localhost:8080/xmlui](localhost:8080/xmlui).
+
+## Theme
+
+The theme for this application, `mit-fol`, is based on the MIT Libraries'
+design system. Where possible, we should copy the stylesheets from that system
+without alteration, and then store customizations in the basic `_style.scss`
+file.

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/_style.scss
@@ -226,3 +226,21 @@ hr.collection-separator {
 #aspect_statistics_StatletTransformer_div_statswrapper .panel-body {
     padding: 0;
 }
+
+.wrap-footer {
+    a {
+        text-decoration: none;
+
+        &:hover,
+        &:active,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
+}
+
+.wrap-outer-footer-institute {
+    a {
+       text-decoration: underline;
+    }
+}

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/mit/_footer.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/mit/_footer.scss
@@ -12,9 +12,12 @@
   a {
     @extend %link;
     color: $white;
+    text-decoration: none;
+
     &:hover,
     &:active,
     &:focus {
+      text-decoration: underline;
       color: $white;
     }
   }
@@ -41,7 +44,7 @@
     }
   }
 
-  .wrap-usergroups {
+  .wrap-policies {
     @extend .list-inline-pipe;
     font-size: $fs-small;
   }
@@ -87,6 +90,12 @@
   font-size: $fs-xxsmall;
   color: $gray-l3;
 
+  .footer-info-institute {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
   a {
     @extend %link;
     color: $white;
@@ -98,7 +107,6 @@
   }
 
   .link-logo-mit {
-    display: inline-block;
 
     .logo-mit {
       fill: $gray-l2;
@@ -110,13 +118,14 @@
   }
 
   .about-mit {
-    @extend .list-inline-pipe;
-    display: inline-block;
     color: $gray-l3;
+    margin-right: 4%;
     text-transform: uppercase;
+    white-space: nowrap;
   }
 
   .license {
+    margin-left: auto;
     margin-top: 1rem;
     color: $gray-l3;
   }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/mit/_layouts.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/mit/_layouts.scss
@@ -125,6 +125,7 @@
       display: inline-block;
       margin-right: 10px;
       font-size: $fs-small;
+      text-decoration: none;
 
       &.current {
         border: 1px solid $brand-primary-accent;
@@ -283,7 +284,7 @@
     margin-bottom: 20px;
   }
 
-  .wrap-usergroups {
+  .wrap-policies {
     width: 100%;
     border-top: 1px solid $gray;
     padding-top: 2rem;
@@ -291,6 +292,10 @@
     span {
       display: inline-block;
       margin: 1rem 1.5rem 1rem 0;
+
+      &.item {
+      margin-right: 0;
+      }
 
       &:after {
         content:'';
@@ -330,7 +335,7 @@
     }
 
     .wrap-logo-lib, 
-    .wrap-usergroups, 
+    .wrap-policies, 
     .wrap-social {
       align-self: flex-end;
       margin-top: 0;
@@ -342,11 +347,11 @@
       margin-right: 4%;
     }
 
-    .wrap-usergroups {
-      order: 3;
-      width: 100%;
-      margin: 1rem 4% 0 0;
+    .wrap-policies {
+      order: 2;
+      padding: auto;
       border-top: none;
+      width: auto;
 
       span {
         margin-top: 0;
@@ -355,22 +360,22 @@
     }
 
     .wrap-social {
-      order: 2;
-      margin-left: 4%;
+      order: 3;
+      margin-left: auto;
     }
   }
 
   // large screen - able to handle several inline items
   @media (min-width: $bp-screen-lg) {
 
-    .wrap-usergroups {
-      order: 2;
-      width: auto;
-    }
-
     .wrap-social {
       order: 3;
     }
+
+    .wrap-policies {
+      order: 2;
+    }
+
   }
 }
 
@@ -378,29 +383,64 @@
 .wrap-footer.footer-slim {
   padding: 1.5rem 4%;
 
-  .footer-main {
+  .wrap-middle {
+    order: 2;
     display: flex;
-    align-items: center;
-  }
+    flex: 1; // No other element gets a value, forcing this element to be greedy in its sizing
+    flex-direction: column;
+    align-items: flex-start;
 
-  .wrap-sitemap {
-    margin-left: 2%;
+    .wrap-policies {
+      align-self: flex-start; // This overrides the flex-end applicable to vertial alignment in full footer.
+    }
 
-    .item {
-      display: block;
-      margin-right: 10px;
+    .wrap-sitemap {
+      display: inline-block;
+      margin-bottom: 2rem;
+
+      .item {
+        display: block;
+        margin-right: 10px;
+        margin-bottom: 5px;
+      }
     }
   }
+
 
   // larger screen - able to handle several inline items
   @media (min-width: $bp-screen-md) {
 
-    .footer-main {
-      align-items: baseline;
+    .wrap-middle {
+      order: 2;
+
+      .wrap-policies {
+        margin-left: 2%;
+        order: 2;
+      }
+
+      .wrap-sitemap {
+        display: inline-block;
+        margin-left: 2%;
+        margin-bottom: auto;
+        order: 1;
+
+        .item {
+          display: inline-block;
+          margin-bottom: auto;
+        }
+      }
     }
 
-    .wrap-sitemap .item {
-      display: inline-block;
+    .wrap-social {
+      order: 3;
+    }
+  }
+
+  @media (min-width: $bp-screen-lg) {
+    .wrap-policies {
+    }
+
+    .wrap-sitemap {
     }
   }
 }

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/core/page-structure.xsl
@@ -635,7 +635,7 @@
                                     <nav aria-label="MIT Libraries policy menu">
                                         <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
                                         <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
-                                        <span class="item"><a href="https://accessibility.mit.edu/" class="link-sub">Accessibility</a></span>
+                                        <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
                                     </nav>
                                 </div>
                             </div>

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/core/page-structure.xsl
@@ -593,18 +593,53 @@
                                     <img src="{$theme-path}/images/mitlib-wordmark.svg" alt="MIT Libraries logo"/>
                                 </a>
                             </div>
+                            <div class="wrap-social">
+                                <p class="text-find-us">Find us on</p>
+                                <a href="https://twitter.com/mitlibraries" title="Twitter">
+                                    <svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black"></path></g></svg>
+                                    <span class="sr">Twitter</span>
+                                </a><!-- End Twitter -->
+
+                                <a href="https://facebook.com/mitlib" title="Facebook">
+                                    <svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black"></path></g></svg>
+                                    <span class="sr">Facebook</span>
+                                </a><!-- End Facebook -->
+
+                                <a href="https://instagram.com/mitlibraries/" title="Instagram">
+                                    <svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1 c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4 C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0 c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4 c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"></path></svg>
+                                    <span class="sr">Instagram</span>
+                                </a><!-- End Instagram -->
+
+                                <a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
+                                    <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+                                    <span class="sr">YouTube</span>
+                                </a><!-- End YouTube -->
+
+                                <a href="https://libguides.mit.edu/mit-feeds" title="RSS">
+                                    <svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black"></path></g></svg>
+                                    <span class="sr">RSS</span>
+                                </a><!-- End RSS -->
+                            </div><!-- end .social -->
+                            <div class="wrap-middle">
+                                <div class="wrap-sitemap">
+                                    <nav class="sitemap-libraries-abbrev" aria-label="MIT Libraries site menu">
+                                        <h2 class="sr">MIT Libraries navigation</h2>
+                                        <a class="item" href="https://libraries.mit.edu/search">Search</a>
+                                        <a class="item" href="https://libraries.mit.edu/hours">Hours &amp; locations</a>
+                                        <a class="item" href="https://libraries.mit.edu/borrow">Borrow &amp; request</a>
+                                        <a class="item" href="https://libraries.mit.edu/research-support">Research support</a>
+                                        <a class="item" href="https://libraries.mit.edu/about">About us</a>
+                                    </nav>
+                                </div><!-- end .links-all -->
+                                <div class="wrap-policies">
+                                    <nav aria-label="MIT Libraries policy menu">
+                                        <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+                                        <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
+                                        <span class="item"><a href="https://accessibility.mit.edu/" class="link-sub">Accessibility</a></span>
+                                    </nav>
+                                </div>
+                            </div>
                         </div><!-- end .identity -->
-                        <div class="wrap-sitemap">
-                            <nav class="sitemap-libraries-abbrev" aria-label="MIT Libraries site menu">
-                                <h2 class="sr">MIT Libraries navigation</h2>
-                                <a class="item" href="https://libraries.mit.edu/">Home</a>
-                                <a class="item" href="https://libraries.mit.edu/search">Search</a>
-                                <a class="item" href="https://libraries.mit.edu/hours">Hours &amp; locations</a>
-                                <a class="item" href="https://libraries.mit.edu/borrow">Borrow &amp; request</a>
-                                <a class="item" href="https://libraries.mit.edu/research-support">Research support</a>
-                                <a class="item" href="https://libraries.mit.edu/about">About the Libraries</a>
-                            </nav>
-                        </div><!-- end .links-all -->
                     </div>
                 </div>
             </div>
@@ -617,10 +652,9 @@
                         </a>
                         <div class="about-mit">
                             <span class="item">Massachusetts Institute of Technology</span>
-                            <span class="item">77 Massachusetts Avenue</span>
-                            <span class="item">Cambridge MA 02139-4307</span>
                         </div>
-                        <div class="license">Items in Dome may be protected by copyright. Please see the MIT Libraries <a href="https://libraries.mit.edu/about/policies/copyright-permissions-policy/">Permissions Policy</a> for rights inquiries, or <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">notify us</a> about copyright concerns.</div><!-- end .footer-info-institute -->
+                        <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
+                        </div><!-- end .footer-info-institute -->
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This implements the footer changes that are being rolled out throughout the Libraries, based on the changes to the design system. It also adds a bit of information about local development to the readme.

Ticket: https://mitlibraries.atlassian.net/browse/UXWS-1014

Old footer:
![Screen Shot 2020-10-01 at 9 59 55 AM](https://user-images.githubusercontent.com/1403248/94819174-f1ceb680-03cc-11eb-8688-32aa036ec774.png)

New footer:
![Screen Shot 2020-10-01 at 9 58 03 AM](https://user-images.githubusercontent.com/1403248/94819189-f85d2e00-03cc-11eb-9edc-8c7f0865f5cb.png)

Once this branch has been deployed to staging, I'll tag everyone for various reviews.