### PR TITLE
Infra 92&219 theme debugging carlj

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/aspect/artifactbrowser/item-view.xsl
@@ -1,30 +1,28 @@
-<xsl:stylesheet
-        xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
-        xmlns:dri="http://di.tamu.edu/DRI/1.0/"
-        xmlns:mets="http://www.loc.gov/METS/"
-        xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
-        xmlns:xlink="http://www.w3.org/TR/xlink/"
-        xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:xalan="http://xml.apache.org/xalan"
-        xmlns:encoder="xalan://java.net.URLEncoder"
-        xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
-        xmlns:jstring="java.lang.String"
-        xmlns:rights="http://cosimo.stanford.edu/sdr/metsrights/"
-        xmlns:confman="org.dspace.core.ConfigurationManager"
-        exclude-result-prefixes="xalan encoder i18n dri mets dim xlink xsl util jstring rights confman">
+<xsl:stylesheet xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+    xmlns:dri="http://di.tamu.edu/DRI/1.0/" xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:dim="http://www.dspace.org/xmlns/dspace/dim" xmlns:xlink="http://www.w3.org/TR/xlink/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns="http://www.w3.org/1999/xhtml" xmlns:xalan="http://xml.apache.org/xalan"
+    xmlns:encoder="xalan://java.net.URLEncoder" xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
+    xmlns:jstring="java.lang.String" xmlns:rights="http://cosimo.stanford.edu/sdr/metsrights/"
+    xmlns:confman="org.dspace.core.ConfigurationManager"
+    exclude-result-prefixes="xalan encoder i18n dri mets dim xlink xsl util jstring rights confman">
 
     <xsl:output indent="yes"/>
     <xsl:variable name="author-limit" select="5"/>
+    <xsl:variable name="creator-limit" select="5"/>
 
     <xsl:template name="itemSummaryView-DIM-file-section">
-        <xsl:variable name="primaryID" select="//mets:structMap[@TYPE='LOGICAL']/mets:div[@TYPE='DSpace Item']/mets:fptr/@FILEID"/>
-        <xsl:variable name="primaryFile" select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[@ID = $primaryID]"/>
+        <xsl:variable name="primaryID"
+            select="//mets:structMap[@TYPE = 'LOGICAL']/mets:div[@TYPE = 'DSpace Item']/mets:fptr/@FILEID"/>
+        <xsl:variable name="primaryFile"
+            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[@ID = $primaryID]"/>
 
         <xsl:variable name="label-1">
             <xsl:choose>
                 <xsl:when test="confman:getProperty('mirage2.item-view.bitstream.href.label.1')">
-                    <xsl:value-of select="confman:getProperty('mirage2.item-view.bitstream.href.label.1')"/>
+                    <xsl:value-of
+                        select="confman:getProperty('mirage2.item-view.bitstream.href.label.1')"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:text>label</xsl:text>
@@ -35,7 +33,8 @@
         <xsl:variable name="label-2">
             <xsl:choose>
                 <xsl:when test="confman:getProperty('mirage2.item-view.bitstream.href.label.2')">
-                    <xsl:value-of select="confman:getProperty('mirage2.item-view.bitstream.href.label.2')"/>
+                    <xsl:value-of
+                        select="confman:getProperty('mirage2.item-view.bitstream.href.label.2')"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:text>title</xsl:text>
@@ -44,100 +43,138 @@
         </xsl:variable>
 
         <xsl:choose>
-            <xsl:when test="string-length($primaryID) &gt; 0 and $primaryFile[@MIMETYPE = 'text/html']">
+            <xsl:when
+                test="string-length($primaryID) &gt; 0 and $primaryFile[@MIMETYPE = 'text/html']">
                 <div class="item-page-field-wrapper table word-break">
 
                     <xsl:call-template name="itemSummaryView-DIM-file-section-entry">
-                        <xsl:with-param name="href" select="$primaryFile/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                        <xsl:with-param name="href"
+                            select="$primaryFile/mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"/>
                         <xsl:with-param name="mimetype" select="$primaryFile/@MIMETYPE"/>
                         <xsl:with-param name="label-1" select="$label-1"/>
                         <xsl:with-param name="label-2" select="$label-2"/>
-                        <xsl:with-param name="title" select="$primaryFile/mets:FLocat[@LOCTYPE='URL']/@xlink:title"/>
-                        <xsl:with-param name="label" select="$primaryFile/mets:FLocat[@LOCTYPE='URL']/@xlink:label"/>
+                        <xsl:with-param name="title"
+                            select="$primaryFile/mets:FLocat[@LOCTYPE = 'URL']/@xlink:title"/>
+                        <xsl:with-param name="label"
+                            select="$primaryFile/mets:FLocat[@LOCTYPE = 'URL']/@xlink:label"/>
                         <xsl:with-param name="size" select="$primaryFile/@SIZE"/>
-                        <xsl:with-param name="licenseKey" select="$primaryFile/mets:FLocat[@LOCTYPE='URL']/@licenseKey"/>
-                        <xsl:with-param name="licenseContent" select="$primaryFile/mets:FLocat[@LOCTYPE='URL']/@licenseContent"/>
+                        <xsl:with-param name="licenseKey"
+                            select="$primaryFile/mets:FLocat[@LOCTYPE = 'URL']/@licenseKey"/>
+                        <xsl:with-param name="licenseContent"
+                            select="$primaryFile/mets:FLocat[@LOCTYPE = 'URL']/@licenseContent"/>
                     </xsl:call-template>
 
-                    <xsl:if test="count(//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file) &gt; 11 and not(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim[@non-archived='y'])">
-                        <xsl:apply-templates mode="itemSummaryView-DIM-disseminate" select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']"/>
+                    <xsl:if
+                        test="count(//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file) &gt; 11 and not(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim[@non-archived = 'y'])">
+                        <xsl:apply-templates mode="itemSummaryView-DIM-disseminate"
+                            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']"
+                        />
                     </xsl:if>
                 </div>
             </xsl:when>
-            <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
+            <xsl:when
+                test="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file">
 
 
                 <div class="item-page-field-wrapper table word-break">
 
-                    <xsl:if test="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[1]">
-                        <xsl:variable name="file" select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[1]"/>
+                    <xsl:if
+                        test="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[1]">
+                        <xsl:variable name="file"
+                            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[1]"/>
                         <xsl:call-template name="itemSummaryView-DIM-file-section-entry">
-                            <xsl:with-param name="href" select="$file/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            <xsl:with-param name="href"
+                                select="$file/mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"/>
                             <xsl:with-param name="mimetype" select="$file/@MIMETYPE"/>
                             <xsl:with-param name="label-1" select="$label-1"/>
                             <xsl:with-param name="label-2" select="$label-2"/>
-                            <xsl:with-param name="title" select="$file/mets:FLocat[@LOCTYPE='URL']/@xlink:title"/>
-                            <xsl:with-param name="label" select="$file/mets:FLocat[@LOCTYPE='URL']/@xlink:label"/>
+                            <xsl:with-param name="title"
+                                select="$file/mets:FLocat[@LOCTYPE = 'URL']/@xlink:title"/>
+                            <xsl:with-param name="label"
+                                select="$file/mets:FLocat[@LOCTYPE = 'URL']/@xlink:label"/>
                             <xsl:with-param name="size" select="$file/@SIZE"/>
                             <xsl:with-param name="embargoDate" select="$file/@EMBARGODATE"/>
-                            <xsl:with-param name="licenseKey" select="$file/mets:FLocat[@LOCTYPE='URL']/@licenseKey"/>
-                            <xsl:with-param name="licenseContent" select="$file/mets:FLocat[@LOCTYPE='URL']/@licenseContent"/>
+                            <xsl:with-param name="licenseKey"
+                                select="$file/mets:FLocat[@LOCTYPE = 'URL']/@licenseKey"/>
+                            <xsl:with-param name="licenseContent"
+                                select="$file/mets:FLocat[@LOCTYPE = 'URL']/@licenseContent"/>
                         </xsl:call-template>
                     </xsl:if>
 
-                    <xsl:if test="count(//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file) &gt; 11 and not(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim[@non-archived='y'])">
-                        <xsl:apply-templates mode="itemSummaryView-DIM-disseminate" select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']"/>
+                    <xsl:if
+                        test="count(//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file) &gt; 11 and not(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim[@non-archived = 'y'])">
+                        <xsl:apply-templates mode="itemSummaryView-DIM-disseminate"
+                            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']"
+                        />
                     </xsl:if>
                 </div>
                 <div class="item-page-field-wrapper table word-break">
 
-                    <xsl:if test="count(//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file) &gt; 1">
+                    <xsl:if
+                        test="count(//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file) &gt; 1">
                         <h5>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.item-files-alternate</i18n:text>
                         </h5>
-                        <xsl:for-each select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[position() &gt; 1]">
-                            <xsl:call-template name="itemSummaryView-DIM-file-section-entry-alternate">
-                                <xsl:with-param name="href" select="mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                        <xsl:for-each
+                            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[position() &gt; 1]">
+                            <xsl:call-template
+                                name="itemSummaryView-DIM-file-section-entry-alternate">
+                                <xsl:with-param name="href"
+                                    select="mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"/>
                                 <xsl:with-param name="mimetype" select="@MIMETYPE"/>
                                 <xsl:with-param name="label-1" select="$label-1"/>
                                 <xsl:with-param name="label-2" select="$label-2"/>
-                                <xsl:with-param name="title" select="mets:FLocat[@LOCTYPE='URL']/@xlink:title"/>
-                                <xsl:with-param name="label" select="mets:FLocat[@LOCTYPE='URL']/@xlink:label"/>
+                                <xsl:with-param name="title"
+                                    select="mets:FLocat[@LOCTYPE = 'URL']/@xlink:title"/>
+                                <xsl:with-param name="label"
+                                    select="mets:FLocat[@LOCTYPE = 'URL']/@xlink:label"/>
                                 <xsl:with-param name="size" select="@SIZE"/>
                                 <xsl:with-param name="embargoDate" select="@EMBARGODATE"/>
-                                <xsl:with-param name="licenseKey" select="mets:FLocat[@LOCTYPE='URL']/@licenseKey"/>
-                                <xsl:with-param name="licenseContent" select="mets:FLocat[@LOCTYPE='URL']/@licenseContent"/>
+                                <xsl:with-param name="licenseKey"
+                                    select="mets:FLocat[@LOCTYPE = 'URL']/@licenseKey"/>
+                                <xsl:with-param name="licenseContent"
+                                    select="mets:FLocat[@LOCTYPE = 'URL']/@licenseContent"/>
                             </xsl:call-template>
                         </xsl:for-each>
                     </xsl:if>
                 </div>
             </xsl:when>
             <!-- Special case for handling ORE resource maps stored as DSpace bitstreams -->
-            <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='ORE']">
-                <xsl:apply-templates select="//mets:fileSec/mets:fileGrp[@USE='ORE']" mode="itemSummaryView-DIM"/>
+            <xsl:when test="//mets:fileSec/mets:fileGrp[@USE = 'ORE']">
+                <xsl:apply-templates select="//mets:fileSec/mets:fileGrp[@USE = 'ORE']"
+                    mode="itemSummaryView-DIM"/>
             </xsl:when>
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template mode="itemSummaryView-DIM-disseminate" match="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']">
+    <xsl:template mode="itemSummaryView-DIM-disseminate"
+        match="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']">
         <div id="mit-item-dissemination">
             <xsl:variable name="action">
-                <xsl:value-of select="$context-path" />
+                <xsl:value-of select="$context-path"/>
                 <xsl:text>/disseminate-package/</xsl:text>
-                <xsl:value-of select="substring-after(ancestor::mets:METS/@ID,':')" />
+                <xsl:value-of select="substring-after(ancestor::mets:METS/@ID, ':')"/>
                 <xsl:text>/</xsl:text>
-                <xsl:value-of select="substring-after(substring-after(ancestor::mets:METS/@ID,':'),'/')" />
+                <xsl:value-of
+                    select="substring-after(substring-after(ancestor::mets:METS/@ID, ':'), '/')"/>
                 <xsl:text>.zip</xsl:text>
             </xsl:variable>
             <form method="POST" action="{$action}" id="dissemination-form">
                 <xsl:choose>
-                    <xsl:when test="../mets:fileGrp[@USE='METADATA']/mets:file/mets:FLocat[@xlink:title = 'imsmanifest.xml']">
-                        <a href="#" onclick="document.getElementById('dissemination-form').submit(); return false;"><i18n:text>xmlui.dri2xhtml.METS-1.0.download-zip.OCW-IMSCP</i18n:text></a>
-                        <input type="hidden" name="package" value="OCW-IMSCP" />
+                    <xsl:when
+                        test="../mets:fileGrp[@USE = 'METADATA']/mets:file/mets:FLocat[@xlink:title = 'imsmanifest.xml']">
+                        <a href="#"
+                            onclick="document.getElementById('dissemination-form').submit(); return false;">
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.download-zip.OCW-IMSCP</i18n:text>
+                        </a>
+                        <input type="hidden" name="package" value="OCW-IMSCP"/>
                     </xsl:when>
                     <xsl:otherwise>
-                        <a href="#" onclick="document.getElementById('dissemination-form').submit(); return false;"><i18n:text>xmlui.dri2xhtml.METS-1.0.download-zip.METS</i18n:text></a>
-                        <input type="hidden" name="package" value="METS" />
+                        <a href="#"
+                            onclick="document.getElementById('dissemination-form').submit(); return false;">
+                            <i18n:text>xmlui.dri2xhtml.METS-1.0.download-zip.METS</i18n:text>
+                        </a>
+                        <input type="hidden" name="package" value="METS"/>
                     </xsl:otherwise>
                 </xsl:choose>
             </form>
@@ -158,9 +195,9 @@
 
         <div>
             <!--<xsl:if test="$embargoDate">-->
-                <!--<i18n:text>xmlui.dri2xhtml.METS-embargo-until</i18n:text>-->
-                <!--<xsl:text> </xsl:text>-->
-                <!--<xsl:value-of select="$embargoDate"/>-->
+            <!--<i18n:text>xmlui.dri2xhtml.METS-embargo-until</i18n:text>-->
+            <!--<xsl:text> </xsl:text>-->
+            <!--<xsl:value-of select="$embargoDate"/>-->
             <!--</xsl:if>-->
             <a class="btn btn-primary download-button">
                 <xsl:attribute name="href">
@@ -181,7 +218,7 @@
         <xsl:if test="$licenseKey != '' and $licenseContent != ''">
             <div class="bitstream-license">
                 <a class="license-key" href="#">
-                    <i aria-hidden="true" class="glyphicon  glyphicon-list-alt"></i>
+                    <i aria-hidden="true" class="glyphicon  glyphicon-list-alt"/>
                     <xsl:text> </xsl:text>
                     <i18n:text>
                         <xsl:value-of select="$licenseKey"/>
@@ -225,7 +262,7 @@
         <xsl:if test="$licenseKey != '' and $licenseContent != ''">
             <div class="bitstream-license">
                 <a class="license-key" href="#">
-                    <i aria-hidden="true" class="glyphicon  glyphicon-list-alt"></i>
+                    <i aria-hidden="true" class="glyphicon  glyphicon-list-alt"/>
                     <xsl:text> </xsl:text>
                     <i18n:text>
                         <xsl:value-of select="$licenseKey"/>
@@ -240,7 +277,8 @@
     <xsl:template match="dim:dim" mode="itemSummaryView-DIM">
         <div class="item-summary-view-metadata">
             <xsl:call-template name="itemSummaryView-DIM-title"/>
-            <xsl:call-template name="itemSummaryView-DIM-authors"/>
+            <!-- <xsl:call-template name="itemSummaryView-DIM-authors"/> -->
+            <xsl:call-template name="itemSummaryView-DIM-authors-creators"/>
 
             <div class="row">
                 <div class="col-sm-4 smaller-font">
@@ -283,29 +321,31 @@
         <xsl:param name="size"/>
         <xsl:param name="embargoDate"/>
         <xsl:choose>
-            <xsl:when test="contains($label-1, 'label') and string-length($label)!=0">
+            <xsl:when test="contains($label-1, 'label') and string-length($label) != 0">
                 <xsl:value-of select="$label"/>
             </xsl:when>
-            <xsl:when test="contains($label-1, 'title') and string-length($title)!=0">
+            <xsl:when test="contains($label-1, 'title') and string-length($title) != 0">
                 <xsl:value-of select="$title"/>
             </xsl:when>
-            <xsl:when test="contains($label-2, 'label') and string-length($label)!=0">
+            <xsl:when test="contains($label-2, 'label') and string-length($label) != 0">
                 <xsl:value-of select="$label"/>
             </xsl:when>
-            <xsl:when test="contains($label-2, 'title') and string-length($title)!=0">
+            <xsl:when test="contains($label-2, 'title') and string-length($title) != 0">
                 <xsl:value-of select="$title"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:call-template name="getFileTypeDesc">
                     <xsl:with-param name="mimetype">
-                        <xsl:value-of select="substring-before($mimetype,'/')"/>
+                        <xsl:value-of select="substring-before($mimetype, '/')"/>
                         <xsl:text>/</xsl:text>
                         <xsl:choose>
-                            <xsl:when test="contains($mimetype,';')">
-                                <xsl:value-of select="substring-before(substring-after($mimetype,'/'),';')"/>
+                            <xsl:when test="contains($mimetype, ';')">
+                                <xsl:value-of
+                                    select="substring-before(substring-after($mimetype, '/'), ';')"
+                                />
                             </xsl:when>
                             <xsl:otherwise>
-                                <xsl:value-of select="substring-after($mimetype,'/')"/>
+                                <xsl:value-of select="substring-after($mimetype, '/')"/>
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:with-param>
@@ -325,15 +365,15 @@
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
             </xsl:when>
             <xsl:when test="$size &lt; 1024 * 1024">
-                <xsl:value-of select="substring(string($size div 1024),1,5)"/>
+                <xsl:value-of select="substring(string($size div 1024), 1, 5)"/>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
             </xsl:when>
             <xsl:when test="$size &lt; 1024 * 1024 * 1024">
-                <xsl:value-of select="substring(string($size div (1024 * 1024)),1,5)"/>
+                <xsl:value-of select="substring(string($size div (1024 * 1024)), 1, 5)"/>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="substring(string($size div (1024 * 1024 * 1024)),1,5)"/>
+                <xsl:value-of select="substring(string($size div (1024 * 1024 * 1024)), 1, 5)"/>
                 <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
             </xsl:otherwise>
         </xsl:choose>
@@ -341,10 +381,11 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-alternative-title">
-        <xsl:if test="dim:field[@element='title' and @qualifier='alternative']">
+        <xsl:if test="dim:field[@element = 'title' and @qualifier = 'alternative']">
             <div class="simple-item-view-alternative-title item-page-field-wrapper">
                 <xsl:choose>
-                    <xsl:when test="count(dim:field[@element='title' and @qualifier='alternative']) > 1">
+                    <xsl:when
+                        test="count(dim:field[@element = 'title' and @qualifier = 'alternative']) > 1">
                         <h5>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.item-alternative-titles</i18n:text>
                         </h5>
@@ -355,7 +396,7 @@
                         </h5>
                     </xsl:otherwise>
                 </xsl:choose>
-                <xsl:for-each select="dim:field[@element='title' and @qualifier='alternative']">
+                <xsl:for-each select="dim:field[@element = 'title' and @qualifier = 'alternative']">
                     <div>
                         <xsl:copy-of select="node()"/>
                     </div>
@@ -365,14 +406,15 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-date">
-        <xsl:if test="dim:field[@element='date' and @qualifier='issued' and descendant::text()]">
+        <xsl:if test="dim:field[@element = 'date' and @qualifier = 'issued' and descendant::text()]">
             <div class="simple-item-view-date word-break item-page-field-wrapper table">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-date</i18n:text>
                 </h5>
-                <xsl:for-each select="dim:field[@element='date' and @qualifier='issued']">
+                <xsl:for-each select="dim:field[@element = 'date' and @qualifier = 'issued']">
                     <xsl:copy-of select="node()"/>
-                    <xsl:if test="count(following-sibling::dim:field[@element='date' and @qualifier='issued']) != 0">
+                    <xsl:if
+                        test="count(following-sibling::dim:field[@element = 'date' and @qualifier = 'issued']) != 0">
                         <br/>
                     </xsl:if>
                 </xsl:for-each>
@@ -381,13 +423,14 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-abstract">
-        <xsl:if test="dim:field[@element='description' and @qualifier='abstract']">
+        <xsl:if test="dim:field[@element = 'description' and @qualifier = 'abstract']">
             <div class="simple-item-view-description item-page-field-wrapper table">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-abstract</i18n:text>
                 </h5>
                 <div>
-                    <xsl:for-each select="dim:field[@element='description' and @qualifier='abstract']">
+                    <xsl:for-each
+                        select="dim:field[@element = 'description' and @qualifier = 'abstract']">
                         <xsl:choose>
                             <xsl:when test="node()">
                                 <xsl:copy-of select="node()"/>
@@ -396,11 +439,13 @@
                                 <xsl:text>&#160;</xsl:text>
                             </xsl:otherwise>
                         </xsl:choose>
-                        <xsl:if test="count(following-sibling::dim:field[@element='description' and @qualifier='abstract']) != 0">
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'description' and @qualifier = 'abstract']) != 0">
                             <div class="spacer">&#160;</div>
                         </xsl:if>
                     </xsl:for-each>
-                    <xsl:if test="count(dim:field[@element='description' and @qualifier='abstract']) &gt; 1">
+                    <xsl:if
+                        test="count(dim:field[@element = 'description' and @qualifier = 'abstract']) &gt; 1">
                         <div class="spacer">&#160;</div>
                     </xsl:if>
                 </div>
@@ -409,13 +454,13 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-description">
-        <xsl:if test="dim:field[@element='description' and not(@qualifier)]">
+        <xsl:if test="dim:field[@element = 'description' and not(@qualifier)]">
             <div class="simple-item-view-description item-page-field-wrapper table">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-description</i18n:text>
                 </h5>
                 <div>
-                    <xsl:for-each select="dim:field[@element='description' and not(@qualifier)]">
+                    <xsl:for-each select="dim:field[@element = 'description' and not(@qualifier)]">
                         <xsl:choose>
                             <xsl:when test="node()">
                                 <xsl:copy-of select="node()"/>
@@ -424,11 +469,13 @@
                                 <xsl:text>&#160;</xsl:text>
                             </xsl:otherwise>
                         </xsl:choose>
-                        <xsl:if test="count(following-sibling::dim:field[@element='description' and not(@qualifier)]) != 0">
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'description' and not(@qualifier)]) != 0">
                             <div class="spacer">&#160;</div>
                         </xsl:if>
                     </xsl:for-each>
-                    <xsl:if test="count(dim:field[@element='description' and not(@qualifier)]) &gt; 1">
+                    <xsl:if
+                        test="count(dim:field[@element = 'description' and not(@qualifier)]) &gt; 1">
                         <div class="spacer">&#160;</div>
                     </xsl:if>
                 </div>
@@ -437,15 +484,16 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-worktype">
-        <xsl:if test="dim:field[@element='worktype' and not(@qualifier)]">
+        <xsl:if test="dim:field[@element = 'worktype' and not(@qualifier)]">
             <div class="simple-item-view-worktype item-page-field-wrapper">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-worktype</i18n:text>
                 </h5>
                 <span>
-                    <xsl:for-each select="dim:field[@element='worktype' and not(@qualifier)]">
+                    <xsl:for-each select="dim:field[@element = 'worktype' and not(@qualifier)]">
                         <xsl:copy-of select="node()"/>
-                        <xsl:if test="count(following-sibling::dim:field[@element='worktype' and not(@qualifier)]) != 0">
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'worktype' and not(@qualifier)]) != 0">
                             <span class="spacer">;&#160;</span>
                         </xsl:if>
                     </xsl:for-each>
@@ -455,15 +503,16 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-genre">
-        <xsl:if test="dim:field[@element='genre' and not(@qualifier)]">
+        <xsl:if test="dim:field[@element = 'genre' and not(@qualifier)]">
             <div class="simple-item-view-genre item-page-field-wrapper">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-genre</i18n:text>
                 </h5>
                 <span>
-                    <xsl:for-each select="dim:field[@element='genre' and not(@qualifier)]">
+                    <xsl:for-each select="dim:field[@element = 'genre' and not(@qualifier)]">
                         <xsl:copy-of select="node()"/>
-                        <xsl:if test="count(following-sibling::dim:field[@element='genre' and not(@qualifier)]) != 0">
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'genre' and not(@qualifier)]) != 0">
                             <span class="spacer">;&#160;</span>
                         </xsl:if>
                     </xsl:for-each>
@@ -473,15 +522,16 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-subject">
-        <xsl:if test="dim:field[@element='subject' and not(@qualifier)]">
+        <xsl:if test="dim:field[@element = 'subject' and not(@qualifier)]">
             <div class="simple-item-view-subject item-page-field-wrapper">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-subject</i18n:text>
                 </h5>
                 <div>
-                    <xsl:for-each select="dim:field[@element='subject' and not(@qualifier)]">
+                    <xsl:for-each select="dim:field[@element = 'subject' and not(@qualifier)]">
                         <xsl:copy-of select="node()"/>
-                        <xsl:if test="count(following-sibling::dim:field[@element='subject' and not(@qualifier)]) != 0">
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'subject' and not(@qualifier)]) != 0">
                             <xsl:text>, </xsl:text>
                         </xsl:if>
                     </xsl:for-each>
@@ -492,28 +542,29 @@
 
     <xsl:template name="itemSummaryView-DIM-terms">
         <!-- Please note the mismatch here between using "terms" in the template and the metadata value of "rights" -->
-        <xsl:if test="dim:field[@element='rights' and (not(@qualifier) or @qualifier='uri')]">
+        <xsl:if test="dim:field[@element = 'rights' and (not(@qualifier) or @qualifier = 'uri')]">
             <div class="simple-item-view-terms item-page-field-wrapper">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-terms</i18n:text>
                 </h5>
                 <div>
-                    <xsl:copy-of select="dim:field[@element='rights' and not(@qualifier)]"/>
-                    <xsl:if test="dim:field[@element='rights' and @qualifier='uri']">
+                    <xsl:copy-of select="dim:field[@element = 'rights' and not(@qualifier)]"/>
+                    <xsl:if test="dim:field[@element = 'rights' and @qualifier = 'uri']">
                         <a href="{dim:field[@element='rights' and @qualifier='uri']/text()}">
-                            <xsl:copy-of select="dim:field[@element='rights' and @qualifier='uri']"/>
+                            <xsl:copy-of
+                                select="dim:field[@element = 'rights' and @qualifier = 'uri']"/>
                         </a>
                     </xsl:if>
                 </div>
             </div>
         </xsl:if>
-        <xsl:if test="dim:field[@element='rights' and @qualifier='access']">
+        <xsl:if test="dim:field[@element = 'rights' and @qualifier = 'access']">
             <div class="simple-item-view-terms item-page-field-wrapper">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-rights-access</i18n:text>
                 </h5>
                 <div>
-                    <xsl:for-each select="dim:field[@element='rights' and @qualifier='access']">
+                    <xsl:for-each select="dim:field[@element = 'rights' and @qualifier = 'access']">
                         <xsl:copy-of select="node()"/>
                     </xsl:for-each>
                 </div>
@@ -522,13 +573,14 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-ispartof">
-        <xsl:if test="dim:field[@element='relation' and @qualifier='ispartof']">
+        <xsl:if test="dim:field[@element = 'relation' and @qualifier = 'ispartof']">
             <div class="simple-item-view-ispartof item-page-field-wrapper">
                 <h5>
                     <i18n:text>xmlui.dri2xhtml.METS-1.0.item-ispartof</i18n:text>
                 </h5>
                 <div>
-                    <xsl:for-each select="dim:field[@element='relation' and @qualifier='ispartof']">
+                    <xsl:for-each
+                        select="dim:field[@element = 'relation' and @qualifier = 'ispartof']">
                         <xsl:copy-of select="node()"/>
                     </xsl:for-each>
                 </div>
@@ -536,84 +588,157 @@
         </xsl:if>
     </xsl:template>
 
+
     <xsl:template name="itemSummaryView-DIM-authors">
         <div class="simple-item-view-authors item-page-field-wrapper table">
             <xsl:choose>
-                <xsl:when test="dim:field[@element='contributor'][@qualifier='display']">
-                    <xsl:for-each select="dim:field[@element='contributor'][@qualifier='display']">
-                        <span>
-                            <xsl:if test="@authority">
-                                <xsl:attribute name="class"><xsl:text>ds-dc_contributor_author-authority</xsl:text></xsl:attribute>
-                            </xsl:if>
-                            <xsl:copy-of select="node()"/>
-                        </span>
-                        <xsl:if test="count(following-sibling::dim:field[@element='contributor'][@qualifier='display']) != 0">
-                            <xsl:text>; </xsl:text>
+                <xsl:when
+                    test="dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)]">
+                    <xsl:variable name="author-total"
+                        select="count(dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)])"/>
+                    <xsl:for-each
+                        select="dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)]">
+                        <xsl:call-template name="itemSummaryView-DIM-authors-entry">
+                            <xsl:with-param name="index" select="position()"/>
+                        </xsl:call-template>
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)]) != 0">
+                            <span>
+                                <xsl:attribute name="class">
+                                    <xsl:text>author-spacer-list-</xsl:text>
+                                    <xsl:value-of select="position() + 1"/>
+
+                                    <xsl:if
+                                        test="position() + 1 &gt; $author-limit and $author-limit &gt; 0">
+                                        <xsl:text> hidden </xsl:text>
+                                    </xsl:if>
+                                </xsl:attribute>
+                                <xsl:text>;&#160;</xsl:text>
+                            </span>
                         </xsl:if>
                     </xsl:for-each>
+                    <xsl:if test="$author-total &gt; $author-limit and $author-limit &gt; 0">
+                        <span id="item-view-authors-truncated">
+                            <xsl:text>; ...</xsl:text>
+                        </span>
+                        <span>
+                            <xsl:text>&#160;</xsl:text>
+                        </span>
+                        <span>
+                            <a id="item-view-show-all-authors-link" href="#"
+                                onClick="showAuthors(); return false;">Show more </a>
+                            <a id="item-view-hide-authors-link" href="#"
+                                onClick="hideAuthors(); return false;" class="hidden">Show less </a>
+                        </span>
+                    </xsl:if>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:choose>
-                        <xsl:when test="dim:field[@element='contributor'][@qualifier='author' or not(@qualifier)]">
-                            <xsl:variable name="author-total" select="count(dim:field[@element='contributor'][@qualifier='author' or not(@qualifier)])"/>
-                            <xsl:for-each select="dim:field[@element='contributor'][@qualifier='author' or not(@qualifier)]">
-                                <xsl:call-template name="itemSummaryView-DIM-authors-entry">
-                                    <xsl:with-param name="index" select="position()"/>
-                                </xsl:call-template>
-                                <xsl:if test="count(following-sibling::dim:field[@element='contributor'][@qualifier='author' or not(@qualifier)]) != 0">
-                                    <span>
-                                        <xsl:attribute name="class">
-                                            <xsl:text>author-spacer-list-</xsl:text>
-                                            <xsl:value-of select="position()+1"/>
-
-                                            <xsl:if test="position()+1 &gt; $author-limit and $author-limit &gt; 0">
-                                                <xsl:text> hidden </xsl:text>
-                                            </xsl:if>
-                                        </xsl:attribute>
-                                        <xsl:text>;&#160;</xsl:text>
-                                    </span>
-                                </xsl:if>
-                            </xsl:for-each>
-                            <xsl:if test="$author-total &gt; $author-limit and $author-limit &gt; 0">
-                                <span id="item-view-authors-truncated">
-                                    <xsl:text>; ...</xsl:text>
-                                </span>
-                                <span>
-                                    <xsl:text>&#160;</xsl:text>
-                                </span>
-                                <span>
-                                    <a id="item-view-show-all-authors-link" href="#" onClick="showAuthors(); return false;">Show
-                                        more
-                                    </a>
-                                    <a id="item-view-hide-authors-link" href="#" onClick="hideAuthors(); return false;"
-                                       class="hidden">Show less
-                                    </a>
-                                </span>
-                            </xsl:if>
-                        </xsl:when>
-                        <xsl:when test="dim:field[@element='creator']">
-                            <xsl:for-each select="dim:field[@element='creator']">
-                                <xsl:copy-of select="node()"/>
-                                <xsl:if test="count(following-sibling::dim:field[@element='creator']) != 0">
-                                    <xsl:text>; </xsl:text>
-                                </xsl:if>
-                            </xsl:for-each>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
-                        </xsl:otherwise>
-                    </xsl:choose>
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
                 </xsl:otherwise>
             </xsl:choose>
         </div>
     </xsl:template>
+
+    <!-- Check for both dc.contributor.* and dc.creator -->
+    <xsl:template name="itemSummaryView-DIM-authors-creators">
+        <div class="simple-item-view-authors item-page-field-wrapper table">
+            <xsl:choose>
+                <xsl:when
+                    test="dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)]">
+                    <xsl:variable name="author-total"
+                        select="count(dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)])"/>
+                    <xsl:for-each
+                        select="dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)]">
+                        <xsl:call-template name="itemSummaryView-DIM-authors-entry">
+                            <xsl:with-param name="index" select="position()"/>
+                        </xsl:call-template>
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'contributor'][@qualifier = 'author' or not(@qualifier)]) != 0">
+                            <span>
+                                <xsl:attribute name="class">
+                                    <xsl:text>author-spacer-list-</xsl:text>
+                                    <xsl:value-of select="position() + 1"/>
+
+                                    <xsl:if
+                                        test="position() + 1 &gt; $author-limit and $author-limit &gt; 0">
+                                        <xsl:text> hidden </xsl:text>
+                                    </xsl:if>
+                                </xsl:attribute>
+                                <xsl:text>;&#160;</xsl:text>
+                            </span>
+                        </xsl:if>
+                    </xsl:for-each>
+                    <xsl:if test="$author-total &gt; $author-limit and $author-limit &gt; 0">
+                        <span id="item-view-authors-truncated">
+                            <xsl:text>; ...</xsl:text>
+                        </span>
+                        <span>
+                            <xsl:text>&#160;</xsl:text>
+                        </span>
+                        <span>
+                            <a id="item-view-show-all-authors-link" href="#"
+                                onClick="showAuthors(); return false;">Show more </a>
+                            <a id="item-view-hide-authors-link" href="#"
+                                onClick="hideAuthors(); return false;" class="hidden">Show less </a>
+                        </span>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:when
+                    test="dim:field[@element = 'creator']">
+                    <xsl:variable name="creator-total"
+                        select="count(dim:field[@element = 'creator'])"/>
+                    <xsl:for-each
+                        select="dim:field[@element = 'creator']">
+                        <xsl:call-template name="itemSummaryView-DIM-authors-entry">
+                            <xsl:with-param name="index" select="position()"/>
+                        </xsl:call-template>
+                        <xsl:if
+                            test="count(following-sibling::dim:field[@element = 'creator']) != 0">
+                            <span>
+                                <xsl:attribute name="class">
+                                    <xsl:text>author-spacer-list-</xsl:text>
+                                    <xsl:value-of select="position() + 1"/>
+
+                                    <xsl:if
+                                        test="position() + 1 &gt; $creator-limit and $creator-limit &gt; 0">
+                                        <xsl:text> hidden </xsl:text>
+                                    </xsl:if>
+                                </xsl:attribute>
+                                <xsl:text>;&#160;</xsl:text>
+                            </span>
+                        </xsl:if>
+                    </xsl:for-each>
+                    <xsl:if test="$creator-total &gt; $creator-limit and $creator-limit &gt; 0">
+                        <span id="item-view-authors-truncated">
+                            <xsl:text>; ...</xsl:text>
+                        </span>
+                        <span>
+                            <xsl:text>&#160;</xsl:text>
+                        </span>
+                        <span>
+                            <a id="item-view-show-all-authors-link" href="#"
+                                onClick="showAuthors(); return false;">Show more </a>
+                            <a id="item-view-hide-authors-link" href="#"
+                                onClick="hideAuthors(); return false;" class="hidden">Show less </a>
+                        </span>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:otherwise>
+                    <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </div>
+    </xsl:template>
+
+    <!-- xmlui.dri2xhtml.METS-1.0.no-author -->
+    <!-- see: /usr/local/dspace6/dspace/webapps/xmlui/i18n/messages.xml -->
 
     <xsl:template name="itemSummaryView-DIM-authors-entry">
         <xsl:param name="index"/>
         <span>
             <xsl:attribute name="class">
                 <xsl:if test="@authority">
-                    <xsl:text> ds-dc_contributor_author-authority </xsl:text>
+                    <xsl:text> ds-dc_contributor_author-authority</xsl:text>
                 </xsl:if>
             </xsl:attribute>
             <span>
@@ -637,15 +762,20 @@
                 <div class="thumbnail">
                     <a class="image-link">
                         <xsl:attribute name="href">
-                            <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            <xsl:value-of select="mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"/>
                         </xsl:attribute>
                         <xsl:choose>
-                            <xsl:when test="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/
-                        mets:file[@GROUPID=current()/@GROUPID]">
+                            <xsl:when
+                                test="
+                                    $context/mets:fileSec/mets:fileGrp[@USE = 'THUMBNAIL']/
+                                    mets:file[@GROUPID = current()/@GROUPID]">
                                 <img class="img-thumbnail" alt="Thumbnail">
                                     <xsl:attribute name="src">
-                                        <xsl:value-of select="$context/mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/
-                                    mets:file[@GROUPID=current()/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                                        <xsl:value-of
+                                            select="
+                                                $context/mets:fileSec/mets:fileGrp[@USE = 'THUMBNAIL']/
+                                                mets:file[@GROUPID = current()/@GROUPID]/mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"
+                                        />
                                     </xsl:attribute>
                                 </img>
                             </xsl:when>
@@ -661,9 +791,11 @@
                         </xsl:choose>
                         <div class="text-center word-break">
                             <xsl:attribute name="title">
-                                <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:title"/>
+                                <xsl:value-of select="mets:FLocat[@LOCTYPE = 'URL']/@xlink:title"/>
                             </xsl:attribute>
-                            <xsl:value-of select="util:shortenString(mets:FLocat[@LOCTYPE='URL']/@xlink:title, 30, 5)"/>
+                            <xsl:value-of
+                                select="util:shortenString(mets:FLocat[@LOCTYPE = 'URL']/@xlink:title, 30, 5)"
+                            />
                         </div>
                     </a>
                 </div>
@@ -678,15 +810,16 @@
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-bytes</i18n:text>
                         </xsl:when>
                         <xsl:when test="@SIZE &lt; 1024 * 1024">
-                            <xsl:value-of select="substring(string(@SIZE div 1024),1,5)"/>
+                            <xsl:value-of select="substring(string(@SIZE div 1024), 1, 5)"/>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-kilobytes</i18n:text>
                         </xsl:when>
                         <xsl:when test="@SIZE &lt; 1024 * 1024 * 1024">
-                            <xsl:value-of select="substring(string(@SIZE div (1024 * 1024)),1,5)"/>
+                            <xsl:value-of select="substring(string(@SIZE div (1024 * 1024)), 1, 5)"/>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-megabytes</i18n:text>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:value-of select="substring(string(@SIZE div (1024 * 1024 * 1024)),1,5)"/>
+                            <xsl:value-of
+                                select="substring(string(@SIZE div (1024 * 1024 * 1024)), 1, 5)"/>
                             <i18n:text>xmlui.dri2xhtml.METS-1.0.size-gigabytes</i18n:text>
                         </xsl:otherwise>
                     </xsl:choose>
@@ -701,14 +834,16 @@
                      and can't really pass that info through. -->
                     <xsl:call-template name="getFileTypeDesc">
                         <xsl:with-param name="mimetype">
-                            <xsl:value-of select="substring-before(@MIMETYPE,'/')"/>
+                            <xsl:value-of select="substring-before(@MIMETYPE, '/')"/>
                             <xsl:text>/</xsl:text>
                             <xsl:choose>
-                                <xsl:when test="contains(@MIMETYPE,';')">
-                                    <xsl:value-of select="substring-before(substring-after(@MIMETYPE,'/'),';')"/>
+                                <xsl:when test="contains(@MIMETYPE, ';')">
+                                    <xsl:value-of
+                                        select="substring-before(substring-after(@MIMETYPE, '/'), ';')"
+                                    />
                                 </xsl:when>
                                 <xsl:otherwise>
-                                    <xsl:value-of select="substring-after(@MIMETYPE,'/')"/>
+                                    <xsl:value-of select="substring-after(@MIMETYPE, '/')"/>
                                 </xsl:otherwise>
                             </xsl:choose>
 
@@ -716,12 +851,14 @@
                     </xsl:call-template>
                 </div>
                 <!-- Display the contents of 'Description' only if bitstream contains a description -->
-                <xsl:if test="mets:FLocat[@LOCTYPE='URL']/@xlink:label != ''">
+                <xsl:if test="mets:FLocat[@LOCTYPE = 'URL']/@xlink:label != ''">
                     <div class="word-break">
                         <xsl:attribute name="title">
-                            <xsl:value-of select="mets:FLocat[@LOCTYPE='URL']/@xlink:label"/>
+                            <xsl:value-of select="mets:FLocat[@LOCTYPE = 'URL']/@xlink:label"/>
                         </xsl:attribute>
-                        <xsl:value-of select="util:shortenString(mets:FLocat[@LOCTYPE='URL']/@xlink:label, 30, 5)"/>
+                        <xsl:value-of
+                            select="util:shortenString(mets:FLocat[@LOCTYPE = 'URL']/@xlink:label, 30, 5)"
+                        />
                     </div>
                 </xsl:if>
             </div>
@@ -749,16 +886,20 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryView-DIM-thumbnail">
-        <xsl:variable name="primaryID" select="//mets:structMap[@TYPE='LOGICAL']/mets:div[@TYPE='DSpace Item']/mets:fptr/@FILEID"/>
-        <xsl:variable name="primaryFile" select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[@ID = $primaryID]"/>
+        <xsl:variable name="primaryID"
+            select="//mets:structMap[@TYPE = 'LOGICAL']/mets:div[@TYPE = 'DSpace Item']/mets:fptr/@FILEID"/>
+        <xsl:variable name="primaryFile"
+            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[@ID = $primaryID]"/>
 
         <div class="thumbnail">
 
             <xsl:choose>
-                <xsl:when test="string-length($primaryID) &gt; 0 and $primaryFile[@MIMETYPE = 'text/html']">
+                <xsl:when
+                    test="string-length($primaryID) &gt; 0 and $primaryFile[@MIMETYPE = 'text/html']">
                     <xsl:variable name="thumbnailHref">
                         <xsl:value-of
-                            select="//mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID = $primaryFile/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                            select="//mets:fileSec/mets:fileGrp[@USE = 'THUMBNAIL']/mets:file[@GROUPID = $primaryFile/@GROUPID]/mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"
+                        />
                     </xsl:variable>
                     <xsl:choose>
                         <xsl:when test="string-length($thumbnailHref) &gt; 0">
@@ -779,12 +920,16 @@
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:when>
-                <xsl:when test="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file">
-                    <xsl:if test="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[1]">
-                        <xsl:variable name="file" select="//mets:fileSec/mets:fileGrp[@USE='CONTENT' or @USE='ORIGINAL' or @USE='LICENSE']/mets:file[1]"/>
+                <xsl:when
+                    test="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file">
+                    <xsl:if
+                        test="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[1]">
+                        <xsl:variable name="file"
+                            select="//mets:fileSec/mets:fileGrp[@USE = 'CONTENT' or @USE = 'ORIGINAL' or @USE = 'LICENSE']/mets:file[1]"/>
                         <xsl:variable name="thumbnailHref">
                             <xsl:value-of
-                                select="//mets:fileSec/mets:fileGrp[@USE='THUMBNAIL']/mets:file[@GROUPID = $file/@GROUPID]/mets:FLocat[@LOCTYPE='URL']/@xlink:href"/>
+                                select="//mets:fileSec/mets:fileGrp[@USE = 'THUMBNAIL']/mets:file[@GROUPID = $file/@GROUPID]/mets:FLocat[@LOCTYPE = 'URL']/@xlink:href"
+                            />
                         </xsl:variable>
                         <xsl:choose>
                             <xsl:when test="string-length($thumbnailHref) &gt; 0">

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/aspect/discovery/discovery.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/aspect/discovery/discovery.xsl
@@ -9,38 +9,25 @@
 -->
 
 <xsl:stylesheet
-        xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
-        xmlns:dri="http://di.tamu.edu/DRI/1.0/"
-        xmlns:mets="http://www.loc.gov/METS/"
-        xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
-        xmlns:xlink="http://www.w3.org/TR/xlink/"
-        xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
-        xmlns="http://www.w3.org/1999/xhtml"
-        xmlns:xalan="http://xml.apache.org/xalan"
-        xmlns:encoder="xalan://java.net.URLEncoder"
-        xmlns:stringescapeutils="org.apache.commons.lang3.StringEscapeUtils"
-        xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
-        xmlns:exslt="http://exslt.org/common"
-        xmlns:confman="org.dspace.core.ConfigurationManager"
-        exclude-result-prefixes="xalan encoder i18n dri mets dim  xlink xsl util stringescapeutils exslt">
+    xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+    xmlns:dri="http://di.tamu.edu/DRI/1.0/"
+    xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+    xmlns:xlink="http://www.w3.org/TR/xlink/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:xalan="http://xml.apache.org/xalan"
+    xmlns:encoder="xalan://java.net.URLEncoder"
+    xmlns:stringescapeutils="org.apache.commons.lang3.StringEscapeUtils"
+    xmlns:util="org.dspace.app.xmlui.utils.XSLUtils"
+    exclude-result-prefixes="xalan encoder i18n dri mets dim  xlink xsl util stringescapeutils">
 
     <xsl:output indent="yes"/>
 
-    <!--
-        These templates are devoted to rendering the search results for discovery.
-        Since discovery uses hit highlighting, separate templates are required !
-    -->
-
-    <xsl:template match="dri:field[@id='aspect.discovery.SimpleSearch.field.query' and @type='text']">
-        <input id="aspect_discovery_SimpleSearch_field_query" class="ds-text-field form-control" name="query"
-               type="text" aria-label="Search MIT DSpace">
-            <xsl:if test="dri:value">
-                <xsl:attribute name="value">
-                    <xsl:value-of select="dri:value"/>
-                </xsl:attribute>
-            </xsl:if>
-        </input>
-    </xsl:template>
+<!--
+    These templates are devoted to rendering the search results for discovery.
+    Since discovery uses hit highlighting, separate templates are required !
+-->
 
 
     <xsl:template match="dri:list[@type='dsolist']" priority="2">
@@ -54,27 +41,27 @@
     </xsl:template>
 
     <xsl:template match="dri:list/dri:list/dri:list" mode="dsoList" priority="8">
-        <!--
-            Retrieve the type from our name, the name contains the following format:
-                {handle}:{metadata}
-        -->
-        <xsl:variable name="handle">
-            <xsl:value-of select="substring-before(@n, ':')"/>
-        </xsl:variable>
-        <xsl:variable name="type">
-            <xsl:value-of select="substring-after(@n, ':')"/>
-        </xsl:variable>
-        <xsl:variable name="externalMetadataURL">
-            <xsl:text>cocoon://metadata/handle/</xsl:text>
-            <xsl:value-of select="$handle"/>
-            <xsl:text>/mets.xml</xsl:text>
-            <!-- Since this is a summary only grab the descriptive metadata, and the thumbnails -->
-            <xsl:text>?sections=dmdSec,fileSec&amp;fileGrpTypes=THUMBNAIL</xsl:text>
-            <!-- An example of requesting a specific metadata standard (MODS and QDC crosswalks only work for items)->
-            <xsl:if test="@type='DSpace Item'">
-                <xsl:text>&amp;dmdTypes=DC</xsl:text>
-            </xsl:if>-->
-        </xsl:variable>
+            <!--
+                Retrieve the type from our name, the name contains the following format:
+                    {handle}:{metadata}
+            -->
+            <xsl:variable name="handle">
+                <xsl:value-of select="substring-before(@n, ':')"/>
+            </xsl:variable>
+            <xsl:variable name="type">
+                <xsl:value-of select="substring-after(@n, ':')"/>
+            </xsl:variable>
+            <xsl:variable name="externalMetadataURL">
+                <xsl:text>cocoon://metadata/handle/</xsl:text>
+                <xsl:value-of select="$handle"/>
+                <xsl:text>/mets.xml</xsl:text>
+                <!-- Since this is a summary only grab the descriptive metadata, and the thumbnails -->
+                <xsl:text>?sections=dmdSec,fileSec&amp;fileGrpTypes=THUMBNAIL</xsl:text>
+                <!-- An example of requesting a specific metadata standard (MODS and QDC crosswalks only work for items)->
+                <xsl:if test="@type='DSpace Item'">
+                    <xsl:text>&amp;dmdTypes=DC</xsl:text>
+                </xsl:if>-->
+            </xsl:variable>
 
 
         <xsl:choose>
@@ -100,8 +87,11 @@
             </xsl:when>
             <xsl:when test="$type='item'">
                 <xsl:call-template name="itemSummaryList">
-                    <xsl:with-param name="identifier">
+                    <xsl:with-param name="handle">
                         <xsl:value-of select="$handle"/>
+                    </xsl:with-param>
+                    <xsl:with-param name="externalMetadataUrl">
+                        <xsl:value-of select="$externalMetadataURL"/>
                     </xsl:with-param>
                 </xsl:call-template>
             </xsl:when>
@@ -133,13 +123,12 @@
                 </xsl:if>
             </a>
             <div class="artifact-info">
-                <xsl:if test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item">
-                    <p>
-                        <xsl:apply-templates
-                                select="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item[1]"/>
-                    </p>
-                </xsl:if>
-            </div>
+            <xsl:if test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item">
+                <p>
+                    <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item[1]"/>
+                </p>
+            </xsl:if>
+        </div>
 
         </div>
     </xsl:template>
@@ -160,265 +149,153 @@
     </xsl:template>
 
     <xsl:template name="itemSummaryList">
-        <xsl:param name="identifier"/>
-        <xsl:variable name="isSimpleNonArchivedSearch">
-            <xsl:choose>
-                <xsl:when test="dri:list[contains(@id, 'SimpleNonArchivedSearch')]">
-                    <xsl:value-of select="'true'"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="'false'"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <xsl:variable name="thumbnails">
-            <xsl:choose>
-                <xsl:when test="dri:list[contains(@id, 'SimpleNonArchivedSearch')]">
-                    <xsl:value-of select="'false'"/>
-                </xsl:when>
-                <xsl:when test="'file' = confman:getProperty('xmlui.theme.mirage.item-list.emphasis')">
-                    <xsl:value-of select="'true'"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="'false'"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <xsl:variable name="handle" select="dri:list[@n=(concat($identifier, ':handle'))]/dri:item/text()"/>
-
-        <xsl:variable name="hasMets">
-            <xsl:choose>
-                <xsl:when test="dri:list[@n=(concat($identifier, ':handle'))]">
-                    <xsl:value-of select="'true'"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="'false'"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-
-
-        <xsl:variable name="externalMetadataUrl">
-            <xsl:text>cocoon://metadata/handle/</xsl:text>
-            <xsl:value-of select="$handle"/>
-            <xsl:text>/mets.xml</xsl:text>
-            <!-- Since this is a summary only grab the descriptive metadata, and the thumbnails -->
-            <xsl:text>?sections=dmdSec,fileSec&amp;fileGrpTypes=THUMBNAIL</xsl:text>
-            <!-- An example of requesting a specific metadata standard (MODS and QDC crosswalks only work for items)->
-            <xsl:if test="@type='DSpace Item'">
-                <xsl:text>&amp;dmdTypes=DC</xsl:text>
-            </xsl:if>-->
-        </xsl:variable>
+        <xsl:param name="handle"/>
+        <xsl:param name="externalMetadataUrl"/>
 
         <xsl:variable name="metsDoc" select="document($externalMetadataUrl)"/>
-        <div class="row ds-artifact-item">
-            <xsl:if test="$thumbnails = 'true'">
-                <div class="col-sm-3 hidden-xs">
-                    <xsl:apply-templates select="$metsDoc/mets:METS/mets:fileSec" mode="artifact-preview">
-                        <xsl:with-param name="href" select="$metsDoc/mets:METS/@OBJID"/>
-                    </xsl:apply-templates>
-                </div>
-            </xsl:if>
-            <div>
-                <xsl:attribute name="class">
-                    <xsl:choose>
-                        <xsl:when test="$thumbnails = 'true'">col-sm-9 artifact-description</xsl:when>
-                        <xsl:otherwise>col-sm-12 artifact-description</xsl:otherwise>
-                    </xsl:choose>
-                </xsl:attribute>
-                <xsl:if test="$isSimpleNonArchivedSearch = 'true'">
-                    <div class="workflow-checkbox">
-                        <span>
-                            <input type="checkbox" name="item-identifier" value="{$identifier}"/>
-                        </span>
-                    </div>
-                </xsl:if>
-                <div>
-                    <xsl:element name="a">
-                        <xsl:attribute name="href">
-                            <xsl:choose>
-                                <xsl:when test="$hasMets = 'true'">
-                                    <xsl:choose>
-                                        <xsl:when
-                                                test="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/@withdrawn or dri:list[@n=(concat($identifier, ':isWithdrawn'))]/dri:item[1]/text() = 'true'">
-                                            <xsl:value-of
-                                                    select="concat($context-path, '/admin/item?itemID=', $identifier)"/>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:value-of select="concat($context-path, '/handle/', $identifier)"/>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of
-                                            select="concat($context-path, '/handle/', $identifier)"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:attribute>
-                        <h4 class="artifact-title">
-                            <xsl:choose>
-                                <xsl:when test="dri:list[@n=(concat($identifier, ':dc.title'))]">
-                                    <xsl:apply-templates
-                                            select="dri:list[@n=(concat($identifier, ':dc.title'))]/dri:item"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            <!-- Generate COinS with empty content per spec but force Cocoon to not create a minified tag  -->
-                            <xsl:if test="$hasMets = 'true'">
-                                <span class="Z3988">
-                                    <xsl:attribute name="title">
-                                        <xsl:for-each
-                                                select="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim">
-                                            <xsl:call-template name="renderCOinS"/>
-                                        </xsl:for-each>
-                                    </xsl:attribute>
-                                    <xsl:text>&#160;</xsl:text>
-                                    <!-- non-breaking space to force separating the end tag -->
-                                </span>
-                            </xsl:if>
-                        </h4>
-                    </xsl:element>
-                    <div class="artifact-info">
-                        <xsl:variable name="author-limit" select="5"/>
-                        <span class="author h4">
-                            <small>
-                                <xsl:choose>
-                                    <xsl:when test="dri:list[@n=(concat($identifier, ':dc.contributor.author'))]">
-                                        <xsl:for-each
-                                                select="dri:list[@n=(concat($identifier, ':dc.contributor.author'))]/dri:item">
 
-                                            <xsl:if test="not(position() &gt; $author-limit)">
-                                                <xsl:variable name="author">
-                                                    <xsl:apply-templates select="."/>
-                                                </xsl:variable>
-                                                <span>
-                                                    <!--Check authority in the mets document-->
-                                                    <xsl:if test="$hasMets = 'true'">
-                                                        <xsl:if test="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@element='contributor' and @qualifier='author' and . = $author]/@authority">
-                                                            <xsl:attribute name="class">
-                                                                <xsl:text>ds-dc_contributor_author-authority</xsl:text>
-                                                            </xsl:attribute>
-                                                        </xsl:if>
-                                                    </xsl:if>
-                                                    <xsl:apply-templates select="."/>
-                                                </span>
+        <div class="row ds-artifact-item ">
 
-                                                <xsl:if test="count(following-sibling::dri:item) != 0">
-                                                    <xsl:text>; </xsl:text>
-                                                </xsl:if>
-                                            </xsl:if>
-                                            <xsl:if test="position() = $author-limit+1">
-                                                <span>
-                                                    <i18n:text>xmlui.dri2xhtml.METS-1.0.e.a.</i18n:text>
-                                                </span>
-                                            </xsl:if>
-                                        </xsl:for-each>
-                                    </xsl:when>
-                                    <xsl:when test="dri:list[@n=(concat($identifier, ':dc.creator'))]">
-                                        <xsl:for-each
-                                                select="dri:list[@n=(concat($identifier, ':dc.creator'))]/dri:item">
-                                            <xsl:if test="not(position() &gt; $author-limit)">
-                                                <xsl:apply-templates select="."/>
-                                                <xsl:if test="count(following-sibling::dri:item) != 0">
-                                                    <xsl:text>; </xsl:text>
-                                                </xsl:if>
-                                            </xsl:if>
-                                            <xsl:if test="position() = $author-limit+1">
-                                                <span>
-                                                    <i18n:text>xmlui.dri2xhtml.METS-1.0.e.a.</i18n:text>
-                                                </span>
-                                            </xsl:if>
-                                        </xsl:for-each>
-                                    </xsl:when>
-                                    <xsl:when test="dri:list[@n=(concat($identifier, ':dc.contributor'))]">
-                                        <xsl:for-each
-                                                select="dri:list[@n=(concat($identifier, ':dc.contributor'))]/dri:item">
-                                            <xsl:if test="not(position() &gt; $author-limit)">
-                                                <xsl:apply-templates select="."/>
-                                                <xsl:if test="count(following-sibling::dri:item) != 0">
-                                                    <xsl:text>; </xsl:text>
-                                                </xsl:if>
-                                            </xsl:if>
-                                            <xsl:if test="position() = $author-limit+1">
-                                                <span>
-                                                    <i18n:text>xmlui.dri2xhtml.METS-1.0.e.a.</i18n:text>
-                                                </span>
-                                            </xsl:if>
-                                        </xsl:for-each>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </small>
-                        </span>
-                        <xsl:text> </xsl:text>
-                        <xsl:if test="dri:list[@n=(concat($identifier, ':dc.date.issued'))]">
-                            <span class="publisher-date h4">
-                                <small>
-                                    <xsl:text>(</xsl:text>
-                                    <xsl:if test="dri:list[@n=(concat($identifier, ':dc.publisher'))]">
-                                        <span class="publisher">
-                                            <xsl:apply-templates
-                                                    select="dri:list[@n=(concat($identifier, ':dc.publisher'))]/dri:item"/>
-                                        </span>
-                                        <xsl:text>, </xsl:text>
-                                    </xsl:if>
-                                    <span class="date">
-                                        <xsl:value-of
-                                                select="substring(dri:list[@n=(concat($identifier, ':dc.date.issued'))]/dri:item,1,10)"/>
-                                    </span>
-                                    <xsl:text>)</xsl:text>
-                                </small>
-                            </span>
-                        </xsl:if>
+            <!--Generates thumbnails (if present)-->
+            <div class="col-sm-3 hidden-xs">
+                <xsl:apply-templates select="$metsDoc/mets:METS/mets:fileSec" mode="artifact-preview">
+                    <xsl:with-param name="href" select="concat($context-path, '/handle/', $handle)"/>
+                </xsl:apply-templates>
+            </div>
+
+
+            <div class="col-sm-9 artifact-description">
+                <xsl:element name="a">
+                    <xsl:attribute name="href">
                         <xsl:choose>
-                            <xsl:when
-                                    test="dri:list[@n=(concat($identifier, ':dc.description.abstract'))]/dri:item/dri:hi">
-                                <div class="abstract">
-                                    <xsl:for-each
-                                            select="dri:list[@n=(concat($identifier, ':dc.description.abstract'))]/dri:item">
-                                        <xsl:apply-templates select="."/>
-                                        <xsl:text>...</xsl:text>
-                                        <br/>
-                                    </xsl:for-each>
-
-                                </div>
+                            <xsl:when test="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/@withdrawn">
+                                <xsl:value-of select="$metsDoc/mets:METS/@OBJEDIT"/>
                             </xsl:when>
-                            <xsl:when test="dri:list[@n=(concat($identifier, ':fulltext'))]">
-                                <div class="abstract">
-                                    <xsl:for-each select="dri:list[@n=(concat($identifier, ':fulltext'))]/dri:item">
-                                        <xsl:apply-templates select="."/>
-                                        <xsl:text>...</xsl:text>
-                                        <br/>
-                                    </xsl:for-each>
-                                </div>
-                            </xsl:when>
-                            <xsl:when test="dri:list[@n=(concat($identifier, ':dc.description.abstract'))]/dri:item">
-                                <div class="abstract">
-                                    <xsl:value-of
-                                            select="util:shortenString(dri:list[@n=(concat($identifier, ':dc.description.abstract'))]/dri:item[1], 220, 10)"/>
-                                </div>
-                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="concat($context-path, '/handle/', $handle)"/>
+                            </xsl:otherwise>
                         </xsl:choose>
-                    </div>
+                    </xsl:attribute>
+                    <h4>
+                        <xsl:choose>
+                            <xsl:when test="dri:list[@n=(concat($handle, ':dc.title'))]">
+                                <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.title'))]/dri:item"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.no-title</i18n:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <!-- Generate COinS with empty content per spec but force Cocoon to not create a minified tag  -->
+                        <span class="Z3988">
+                            <xsl:attribute name="title">
+                                <xsl:for-each select="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim">
+                                    <xsl:call-template name="renderCOinS"/>
+                                </xsl:for-each>
+                            </xsl:attribute>
+                            <xsl:text>&#160;</xsl:text>
+                            <!-- non-breaking space to force separating the end tag -->
+                        </span>
+                    </h4>
+                </xsl:element>
+                <div class="artifact-info">
+                    <span class="author h4">    <small>
+                        <xsl:choose>
+                            <xsl:when test="dri:list[@n=(concat($handle, ':dc.contributor.author'))]">
+                                <xsl:for-each select="dri:list[@n=(concat($handle, ':dc.contributor.author'))]/dri:item">
+                                    <xsl:variable name="author">
+                                        <xsl:apply-templates select="."/>
+                                    </xsl:variable>
+                                    <span>
+                                        <!--Check authority in the mets document-->
+                                        <xsl:if test="$metsDoc/mets:METS/mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@element='contributor' and @qualifier='author' and . = $author]/@authority">
+                                            <xsl:attribute name="class">
+                                                <xsl:text>ds-dc_contributor_author-authority</xsl:text>
+                                            </xsl:attribute>
+                                        </xsl:if>
+                                        <xsl:apply-templates select="."/>
+                                    </span>
+
+                                    <xsl:if test="count(following-sibling::dri:item) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:when test="dri:list[@n=(concat($handle, ':dc.creator'))]">
+                                <xsl:for-each select="dri:list[@n=(concat($handle, ':dc.creator'))]/dri:item">
+                                    <xsl:apply-templates select="."/>
+                                    <xsl:if test="count(following-sibling::dri:item) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:when test="dri:list[@n=(concat($handle, ':dc.contributor'))]">
+                                <xsl:for-each select="dri:list[@n=(concat($handle, ':dc.contributor'))]/dri:item">
+                                    <xsl:apply-templates select="."/>
+                                    <xsl:if test="count(following-sibling::dri:item) != 0">
+                                        <xsl:text>; </xsl:text>
+                                    </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <i18n:text>xmlui.dri2xhtml.METS-1.0.no-author</i18n:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        </small></span>
+                    <xsl:text> </xsl:text>
+                    <xsl:if test="dri:list[@n=(concat($handle, ':dc.date.issued'))]">
+                        <span class="publisher-date h4">   <small>
+                            <xsl:text>(</xsl:text>
+                            <xsl:if test="dri:list[@n=(concat($handle, ':dc.publisher'))]">
+                                <span class="publisher">
+                                    <xsl:apply-templates select="dri:list[@n=(concat($handle, ':dc.publisher'))]/dri:item"/>
+                                </span>
+                                <xsl:text>, </xsl:text>
+                            </xsl:if>
+                            <span class="date">
+                                <xsl:value-of
+                                        select="substring(dri:list[@n=(concat($handle, ':dc.date.issued'))]/dri:item,1,10)"/>
+                            </span>
+                            <xsl:text>)</xsl:text>
+                            </small></span>
+                    </xsl:if>
+                    <xsl:choose>
+                        <xsl:when test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item/dri:hi">
+                            <div class="abstract">
+                                <xsl:for-each select="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item">
+                                    <xsl:apply-templates select="."/>
+                                    <xsl:text>...</xsl:text>
+                                    <br/>
+                                </xsl:for-each>
+
+                            </div>
+                        </xsl:when>
+                        <xsl:when test="dri:list[@n=(concat($handle, ':fulltext'))]">
+                            <div class="abstract">
+                                <xsl:for-each select="dri:list[@n=(concat($handle, ':fulltext'))]/dri:item">
+                                    <xsl:apply-templates select="."/>
+                                    <xsl:text>...</xsl:text>
+                                    <br/>
+                                </xsl:for-each>
+                            </div>
+                        </xsl:when>
+                        <xsl:when test="dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item">
+                        <div class="abstract">
+                                <xsl:value-of select="util:shortenString(dri:list[@n=(concat($handle, ':dc.description.abstract'))]/dri:item[1], 220, 10)"/>
+                        </div>
+                    </xsl:when>
+                    </xsl:choose>
                 </div>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template
-            match="dri:div[@id='aspect.discovery.SimpleSearch.div.discovery-filters-wrapper' or @id='aspect.discovery.SimpleNonArchivedSearch.div.discovery-filters-wrapper']/dri:head">
+    <xsl:template match="dri:div[@id='aspect.discovery.SimpleSearch.div.discovery-filters-wrapper']/dri:head">
         <h3 class="ds-div-head discovery-filters-wrapper-head hidden">
             <xsl:apply-templates/>
         </h3>
     </xsl:template>
 
-    <xsl:template
-            match="dri:list[@id='aspect.discovery.SimpleSearch.list.primary-search' or @id='aspect.discovery.SimpleNonArchivedSearch.list.primary-search']"
-            priority="3">
+    <xsl:template match="dri:list[@id='aspect.discovery.SimpleSearch.list.primary-search']" priority="3">
         <xsl:apply-templates select="dri:head"/>
         <fieldset>
             <xsl:call-template name="standardAttributes">
@@ -431,13 +308,11 @@
                     </xsl:if>
                 </xsl:with-param>
             </xsl:call-template>
-            <xsl:apply-templates select="*[not(name()='label' or name()='head')]"/>
+            <xsl:apply-templates select="*[not(name()='label' or name()='head')]" />
         </fieldset>
     </xsl:template>
 
-    <xsl:template
-            match="dri:list[@id='aspect.discovery.SimpleSearch.list.primary-search' or @id='aspect.discovery.SimpleNonArchivedSearch.list.primary-search' or @id='aspect.discovery.SimpleNonArchivedSearch.list.primary-search']//dri:item[dri:field[@id='aspect.discovery.SimpleSearch.field.query' or @id='aspect.discovery.SimpleNonArchivedSearch.field.query']]"
-            priority="3">
+    <xsl:template match="dri:list[@id='aspect.discovery.SimpleSearch.list.primary-search']//dri:item[dri:field[@id='aspect.discovery.SimpleSearch.field.query']]" priority="3">
         <div>
             <xsl:call-template name="standardAttributes">
                 <xsl:with-param name="class">
@@ -447,28 +322,24 @@
 
             <div class="col-sm-3">
                 <p>
-                    <xsl:apply-templates
-                            select="dri:field[@id='aspect.discovery.SimpleSearch.field.scope' or @id='aspect.discovery.SimpleNonArchivedSearch.field.scope']"/>
+                    <xsl:apply-templates select="dri:field[@id='aspect.discovery.SimpleSearch.field.scope']"/>
                 </p>
             </div>
 
             <div class="col-sm-9">
                 <p class="input-group">
-                    <xsl:apply-templates
-                            select="dri:field[@id='aspect.discovery.SimpleSearch.field.query' or @id='aspect.discovery.SimpleNonArchivedSearch.field.query']"/>
+                    <xsl:apply-templates select="dri:field[@id='aspect.discovery.SimpleSearch.field.query']"/>
                     <span class="input-group-btn">
-                        <xsl:apply-templates
-                                select="dri:field[@id='aspect.discovery.SimpleSearch.field.submit' or @id='aspect.discovery.SimpleNonArchivedSearch.field.submit']"/>
+                        <xsl:apply-templates select="dri:field[@id='aspect.discovery.SimpleSearch.field.submit']"/>
                     </span>
                 </p>
             </div>
         </div>
 
-        <xsl:if test="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean' or @id='aspect.discovery.SimpleNonArchivedSearch.item.did-you-mean']">
+        <xsl:if test="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean']">
             <div class="row">
                 <div class="col-sm-offset-3 col-sm-9">
-                    <xsl:apply-templates
-                            select="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean' or @id='aspect.discovery.SimpleNonArchivedSearch.item.did-you-mean']"/>
+                    <xsl:apply-templates select="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean']"/>
                 </div>
             </div>
         </xsl:if>
@@ -478,9 +349,7 @@
         </div>
     </xsl:template>
 
-    <xsl:template
-            match="dri:list[@id='aspect.discovery.SimpleSearch.list.primary-search' or @id='aspect.discovery.SimpleNonArchivedSearch.list.primary-search']//dri:item[dri:field[@id='aspect.discovery.SimpleSearch.field.query' or @id='aspect.discovery.SimpleNonArchivedSearch.field.query'] and not(dri:field[@id='aspect.discovery.SimpleSearch.field.scope' or @id='aspect.discovery.SimpleNonArchivedSearch.field.scope'])]"
-            priority="3">
+    <xsl:template match="dri:list[@id='aspect.discovery.SimpleSearch.list.primary-search']//dri:item[dri:field[@id='aspect.discovery.SimpleSearch.field.query'] and not(dri:field[@id='aspect.discovery.SimpleSearch.field.scope'])]" priority="3">
         <div>
             <xsl:call-template name="standardAttributes">
                 <xsl:with-param name="class">
@@ -490,39 +359,33 @@
 
             <div class="col-sm-12">
                 <p class="input-group">
-                    <xsl:apply-templates
-                            select="dri:field[@id='aspect.discovery.SimpleSearch.field.query' or @id='aspect.discovery.SimpleNonArchivedSearch.field.query']"/>
+                    <xsl:apply-templates select="dri:field[@id='aspect.discovery.SimpleSearch.field.query']"/>
                     <span class="input-group-btn">
-                        <xsl:apply-templates
-                                select="dri:field[@id='aspect.discovery.SimpleSearch.field.submit' or @id='aspect.discovery.SimpleNonArchivedSearch.field.submit']"/>
+                        <xsl:apply-templates select="dri:field[@id='aspect.discovery.SimpleSearch.field.submit']"/>
                     </span>
                 </p>
             </div>
         </div>
-        <xsl:if test="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean' or @id='aspect.discovery.SimpleNonArchivedSearch.item.did-you-mean']">
-            <xsl:apply-templates
-                    select="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean' or @id='aspect.discovery.SimpleNonArchivedSearch.item.did-you-mean']"/>
+        <xsl:if test="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean']">
+            <xsl:apply-templates select="dri:item[@id='aspect.discovery.SimpleSearch.item.did-you-mean']"/>
         </xsl:if>
         <div id="filters-overview-wrapper-squared"/>
     </xsl:template>
 
-    <xsl:template
-            match="dri:div[@id='aspect.discovery.SimpleSearch.div.search-results' or @id='aspect.discovery.SimpleNonArchivedSearch.div.search-results' or @id='aspect.discovery.workflow.batch.BatchWorkFlowTaskTransformer.div.search-results']/dri:head">
+    <xsl:template match="dri:div[@id='aspect.discovery.SimpleSearch.div.search-results']/dri:head">
         <h4>
             <xsl:call-template name="standardAttributes">
                 <xsl:with-param name="class" select="@rend"/>
             </xsl:call-template>
-            <xsl:apply-templates/>
+            <xsl:apply-templates />
         </h4>
     </xsl:template>
 
-    <xsl:template
-            match="dri:table[@id='aspect.discovery.SimpleSearch.table.discovery-filters' or @id='aspect.discovery.SimpleNonArchivedSearch.table.discovery-filters']">
+    <xsl:template match="dri:table[@id='aspect.discovery.SimpleSearch.table.discovery-filters']">
         <xsl:apply-templates/>
     </xsl:template>
 
-    <xsl:template
-            match="dri:table[@id='aspect.discovery.SimpleSearch.table.discovery-filters' or @id='aspect.discovery.SimpleNonArchivedSearch.table.discovery-filters']/dri:row">
+    <xsl:template match="dri:table[@id='aspect.discovery.SimpleSearch.table.discovery-filters']/dri:row">
         <script type="text/javascript">
             <xsl:text>
                 if (!window.DSpace) {
@@ -535,21 +398,15 @@
                     window.DSpace.discovery.filters = [];
                 }
                 window.DSpace.discovery.filters.push({
-                    type: '</xsl:text><xsl:value-of
-                select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filtertype')]/dri:value/@option)"/><xsl:text>',
-                    relational_operator: '</xsl:text><xsl:value-of
-                select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filter_relational_operator')]/dri:value/@option)"/><xsl:text>',
-                    query: '</xsl:text><xsl:value-of
-                select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[@rend = 'discovery-filter-input']/dri:value)"/><xsl:text>',
-                    label: '</xsl:text><xsl:value-of
-                select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[@rend = 'discovery-filter-label']/dri:value)"/><xsl:text>',
-            });
+                    type: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filtertype')]/dri:value/@option)"/><xsl:text>',
+                    relational_operator: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filter_relational_operator')]/dri:value/@option)"/><xsl:text>',
+                    query: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[@rend = 'discovery-filter-input']/dri:value)"/><xsl:text>',
+                });
             </xsl:text>
         </script>
     </xsl:template>
 
-    <xsl:template
-            match="dri:row[starts-with(@id, 'aspect.discovery.SimpleSearch.row.filter-new-') or starts-with(@id, 'aspect.discovery.SimpleNonArchivedSearch.row.filter-new-')]">
+    <xsl:template match="dri:row[starts-with(@id, 'aspect.discovery.SimpleSearch.row.filter-new-')]">
         <script type="text/javascript">
             <xsl:text>
                 if (!window.DSpace) {
@@ -567,7 +424,7 @@
         <xsl:text>
             if (!window.DSpace.i18n) {
                 window.DSpace.i18n = {};
-            }
+            } 
             if (!window.DSpace.i18n.discovery) {
                 window.DSpace.i18n.discovery = {};
             }
@@ -593,13 +450,12 @@
                     <xsl:text>']='</xsl:text>
                     <xsl:copy-of select="./*"/>
                     <xsl:text>';</xsl:text>
-                </xsl:for-each>
+                 </xsl:for-each>
             </xsl:for-each>
         </script>
     </xsl:template>
 
-    <xsl:template
-            match="dri:row[@id='aspect.discovery.SimpleSearch.row.filter-controls' or @id='aspect.discovery.SimpleNonArchivedSearch.row.filter-controls']">
+    <xsl:template match="dri:row[@id='aspect.discovery.SimpleSearch.row.filter-controls']">
         <div>
             <xsl:call-template name="standardAttributes">
                 <xsl:with-param name="class">
@@ -608,13 +464,12 @@
             </xsl:call-template>
 
             <div>
-                <xsl:apply-templates/>
+                    <xsl:apply-templates/>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template
-            match="dri:field[starts-with(@id, 'aspect.discovery.SimpleSearch.field.add-filter') or starts-with(@id, 'aspect.discovery.SimpleNonArchivedSearch.field.add-filter')]">
+    <xsl:template match="dri:field[starts-with(@id, 'aspect.discovery.SimpleSearch.field.add-filter')]">
         <button>
             <xsl:call-template name="fieldAttributes"/>
             <xsl:attribute name="type">submit</xsl:attribute>
@@ -637,8 +492,7 @@
         </button>
     </xsl:template>
 
-    <xsl:template
-            match="dri:field[starts-with(@id, 'aspect.discovery.SimpleSearch.field.remove-filter') or starts-with(@id, 'aspect.discovery.SimpleNonArchivedSearch.field.remove-filter')]">
+    <xsl:template match="dri:field[starts-with(@id, 'aspect.discovery.SimpleSearch.field.remove-filter')]">
         <button>
             <xsl:call-template name="fieldAttributes"/>
             <xsl:attribute name="type">submit</xsl:attribute>
@@ -760,5 +614,6 @@
         </xsl:if>
 
     </xsl:template>
+
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR contains the current changes to the mit-fol theme on dome.mit.edu.  These changes are currently in production but not reflected in our current release.  The mit-fol theme is based on Atmire's implementation of the standard MIT theme on dspace.mit.edu. However,  because the dome.mit.edu codebase is based on the standard DSpace 6.3 release it lacks some of the proprietary Atmire 'hooks' present on dspace.mit.edu we discovered  the mit-fol theme in certain cases responds somewhat differently on Dome.  This PR restores the ability to display thumbnails in search results by using the default 6.3 discovery.xsl (.../themes/mit-fol/xsl/custom/aspect/discovery/discovery.xsl) and 2) adds the display of dc.creator field to the Simple Item View page, which was set to only displaying dc.contributor.author (...themes/mit-fol/xsl/custom/aspect/artifactbrowser/item-view.xsl). 

Now Simple Item View can display either dc.creator or dc.contributor/dc.contributor.author field contents.  The template will not display both creator and contributor (dc.contributor.* taking precedence if both fields are present).

See Jira tickets: 
https://mitlibraries.atlassian.net/browse/INFRA-92 
https://mitlibraries.atlassian.net/browse/INFRA-219

Question. There were also 2 changes made to the latest dspace.cfg (again, see ticket INFRA-92) that removes the user registration button from public view and another option which sets item-list emphasis to file.  I'm not sure if we maintain dspace.cfg file changes in GitHub?  

dspace.cfg: 
xmlui.theme.mirage.item-list.emphasis = file
xmlui.user.registration=false 

Note: the mit-fol theme uses the responsive Mirage2 theme framework and requires slightly different build procedures than Mirage 1 themes.  This apparently caused some problems at first but Alex now has the correct procedures and dependencies in place to build Mirage2 themes.

