### PR TITLE
Fix breadcrumb separator in theme SCSS

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/_style.scss
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/styles/_style.scss
@@ -244,3 +244,8 @@ hr.collection-separator {
        text-decoration: underline;
     }
 }
+
+/* Overriding the malformed breadcrumb characters in _bootstrap_variables.scss */
+.breadcrumb>li+li:before {
+  content: '>';
+}


### PR DESCRIPTION
### Why these changes are being introduced:

The breadcrumb separator characters are rendered with an unwanted `Â`
characte. The problem appears to be that the non-breaking space UTF-8
characters, which SASS adds after the breadcrumb separator, are encoded as
ASCII at some point in the build process, before being rendered as UTF-8.
(The byte for non-breaking space in ASCII is the same byte as the `Â`
character in UTF-8.)

This is not a problem in current Dome prod because the `main.css`
file was manually fixed and put into place in the server in October
2021 to solve a similar issue (see INFRA-193). We are seeing it now
because dev1 has the programmatically generated CSS.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IN-773
* https://mitlibraries.atlassian.net/browse/INFRA-193

### How this addresses that need:

This changes the the separator from the unicode character to `>`, and
sets the style in `_style.scss`. Since this file is loaded after
`_bootstrap_variables.scss`, it overrides the rule in that file. It
also avoids the SASS compilation process, so the Unicode artifact
is not introduced.

### Side effects of this change:

We haven't solved the root problem, which is that something in the
build process (likely the SASS preprocessor) is double-encoding in
ASCII and UTF-8. However, it may not be worth resolving at this point,
as we will be upgrading to DSpace 7 in the near future.