### PR TITLE
Add Matomo tracking code

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/core/page-structure.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/mit-fol/xsl/custom/core/page-structure.xsl
@@ -805,24 +805,25 @@
             <xsl:call-template name="choiceLookupPopUpSetup"/>
         </xsl:if>
 
-        <xsl:call-template name="addJavascript-google-analytics"/>
+        <xsl:call-template name="addJavascript-matomo-analytics"/>
 
     </xsl:template>
 
-    <xsl:template name="addJavascript-google-analytics">
-        <!-- Add a google analytics script if the key is present -->
-        <xsl:if test="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']">
-            <script><xsl:text>
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-                ga('create', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='google'][@qualifier='analytics']"/><xsl:text>', '</xsl:text><xsl:value-of select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='request'][@qualifier='serverName']"/><xsl:text>');
-                ga('send', 'pageview');
-            </xsl:text>
-            </script>
-        </xsl:if>
+    <xsl:template name="addJavascript-matomo-analytics">
+      <script><xsl:text>
+          var _paq = window._paq = window._paq || [];
+          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="https://matomo.libraries.mit.edu/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '8']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          })();
+      </xsl:text>
+      </script>
     </xsl:template>
 
     <!--The Language Selection


### PR DESCRIPTION
### Why these changes are being introduced:

We want to track site analytics on Dome.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/UXWS-1568

### How this addresses that need:

This adds the Matomo tracking code to the page-structure XSLT.

### Side effects of this change:

The site URL and ID are hardcoded, meaning that any future changes to these values will require an additional commit. We normally prefer to abstract this information to config variables, but there is not a particularly intuitive way to do this in DSpace.